### PR TITLE
Introduce AutoService for feature discovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,9 +32,8 @@ dependencies {
 	include "jakarta.inject:jakarta.inject-api:2.0.1"
 	include "org.glassfish:javax.json:1.1.4"
 
-	// Reflections + dependencies
-	include implementation("org.reflections:reflections:0.9.12")
-	include "org.javassist:javassist:3.26.0-GA"
+	// AutoService
+	annotationProcessor implementation("com.google.auto.service:auto-service:1.1.0")
 
 	// To change the versions see the gradle.properties file
 	minecraft("com.mojang:minecraft:${project.minecraft_version}")

--- a/src/main/java/tools/redstone/redstonetools/RedstoneToolsClient.java
+++ b/src/main/java/tools/redstone/redstonetools/RedstoneToolsClient.java
@@ -23,12 +23,13 @@ public class RedstoneToolsClient implements ClientModInitializer {
         RedstoneToolsGameRules.register();
 
         // Register features
-        for (var featureClass : ReflectionUtils.getFeatureClasses()) {
-            var feature = INJECTOR.getInstance(featureClass);
+        ReflectionUtils.getFeatures().forEach(feature -> {
+            LOGGER.trace("Registering feature {}", feature);
 
             feature.register();
-        }
+        });
 
-        WorldlessCommandHelper.dummyNetworkHandler.getCommandDispatcher();// should call the "static" method
+        // should call the "static" block
+        WorldlessCommandHelper.dummyNetworkHandler.getCommandDispatcher();
     }
 }

--- a/src/main/java/tools/redstone/redstonetools/di/FeatureModule.java
+++ b/src/main/java/tools/redstone/redstonetools/di/FeatureModule.java
@@ -1,13 +1,17 @@
 package tools.redstone.redstonetools.di;
 
+import com.google.auto.service.AutoService;
 import com.google.inject.AbstractModule;
 import tools.redstone.redstonetools.utils.ReflectionUtils;
 
+@AutoService(AbstractModule.class)
 public class FeatureModule extends AbstractModule {
+    @SuppressWarnings({"rawtypes", "unchecked"}) // this is probably the only way to make it work
     @Override
     protected void configure() {
-        for (var featureClass : ReflectionUtils.getFeatureClasses()) {
-            bind(featureClass).asEagerSingleton();
+        for (var feature : ReflectionUtils.getFeatures()) {
+            Class clazz = feature.getClass();
+            bind(clazz).toInstance(feature);
         }
     }
 }

--- a/src/main/java/tools/redstone/redstonetools/di/MacroModule.java
+++ b/src/main/java/tools/redstone/redstonetools/di/MacroModule.java
@@ -1,8 +1,10 @@
 package tools.redstone.redstonetools.di;
 
+import com.google.auto.service.AutoService;
 import tools.redstone.redstonetools.macros.MacroManager;
 import com.google.inject.AbstractModule;
 
+@AutoService(AbstractModule.class)
 public class MacroModule extends AbstractModule {
 
     private static MacroManager macroManager;

--- a/src/main/java/tools/redstone/redstonetools/di/TelemetryModule.java
+++ b/src/main/java/tools/redstone/redstonetools/di/TelemetryModule.java
@@ -1,9 +1,11 @@
 package tools.redstone.redstonetools.di;
 
+import com.google.auto.service.AutoService;
 import tools.redstone.redstonetools.telemetry.TelemetryClient;
 import com.google.inject.AbstractModule;
 import tools.redstone.redstonetools.telemetry.TelemetryManager;
 
+@AutoService(AbstractModule.class)
 public class TelemetryModule extends AbstractModule {
     private static TelemetryClient telemetryClient;
     private static TelemetryManager telemetryManager;

--- a/src/main/java/tools/redstone/redstonetools/di/UtilityModule.java
+++ b/src/main/java/tools/redstone/redstonetools/di/UtilityModule.java
@@ -1,9 +1,11 @@
 package tools.redstone.redstonetools.di;
 
+import com.google.auto.service.AutoService;
 import tools.redstone.redstonetools.features.feedback.AbstractFeedbackSender;
 import tools.redstone.redstonetools.features.feedback.FeedbackSender;
 import com.google.inject.AbstractModule;
 
+@AutoService(AbstractModule.class)
 public class UtilityModule extends AbstractModule {
     @Override
     protected void configure() {

--- a/src/main/java/tools/redstone/redstonetools/features/commands/BaseConvertFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BaseConvertFeature.java
@@ -1,6 +1,8 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
 import net.minecraft.server.command.ServerCommandSource;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -10,6 +12,7 @@ import java.math.BigInteger;
 import static tools.redstone.redstonetools.features.arguments.serializers.BigIntegerSerializer.bigInteger;
 import static tools.redstone.redstonetools.features.arguments.serializers.NumberBaseSerializer.numberBase;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Base Convert", description = "Converts a number from one base to another.", command = "base")
 public class BaseConvertFeature extends CommandFeature {
 

--- a/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -16,6 +18,7 @@ import static tools.redstone.redstonetools.features.arguments.serializers.BoolSe
 import static tools.redstone.redstonetools.features.arguments.serializers.IntegerSerializer.integer;
 import static tools.redstone.redstonetools.features.arguments.serializers.NumberBaseSerializer.numberBase;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Binary Block Read", description = "Interprets your WorldEdit selection as a binary number.", command = "/read")
 public class BinaryBlockReadFeature extends CommandFeature {
     private static final BlockStateArgument LIT_LAMP_ARG = new BlockStateArgument(

--- a/src/main/java/tools/redstone/redstonetools/features/commands/ColorCodeFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/ColorCodeFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -21,6 +23,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import org.jetbrains.annotations.Nullable;
 import static tools.redstone.redstonetools.features.arguments.serializers.BlockColorSerializer.blockColor;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Color Code", description = "Color codes all color-able blocks in your WorldEdit selection.", command = "/colorcode")
 public class ColorCodeFeature extends CommandFeature {
     public static final Argument<BlockColor> color = Argument

--- a/src/main/java/tools/redstone/redstonetools/features/commands/CopyStateFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/CopyStateFeature.java
@@ -1,5 +1,6 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
 import com.mojang.datafixers.util.Either;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
@@ -8,12 +9,14 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
 import net.minecraft.server.command.ServerCommandSource;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.feedback.Feedback;
 import tools.redstone.redstonetools.mixin.accessors.MinecraftClientAccessor;
 import tools.redstone.redstonetools.utils.BlockInfo;
 import tools.redstone.redstonetools.utils.BlockStateNbtUtil;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Copy State", description = "Gives you a copy of the block you're looking at with its BlockState.", command = "copystate")
 public class CopyStateFeature extends PickBlockFeature {
     @Override

--- a/src/main/java/tools/redstone/redstonetools/features/commands/GlassFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/GlassFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.feedback.Feedback;
 import tools.redstone.redstonetools.utils.BlockColor;
@@ -15,6 +17,7 @@ import net.minecraft.util.registry.Registry;
 
 import javax.annotation.Nullable;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Glass", description = "Converts colored blocks to their glass variant and glass to wool.", command = "glass")
 public class GlassFeature extends PickBlockFeature {
     @Override

--- a/src/main/java/tools/redstone/redstonetools/features/commands/MacroFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/MacroFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -9,7 +11,7 @@ import net.minecraft.server.command.ServerCommandSource;
 import static tools.redstone.redstonetools.RedstoneToolsClient.INJECTOR;
 import static tools.redstone.redstonetools.features.arguments.serializers.MacroNameSerializer.macroName;
 
-
+@AutoService(AbstractFeature.class)
 @Feature(command = "macro", description = "Allows you to execute a macro", name = "Macro")
 public class MacroFeature extends CommandFeature {
     public static final Argument<String> macro = Argument.ofType(macroName());

--- a/src/main/java/tools/redstone/redstonetools/features/commands/MinSelectionFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/MinSelectionFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.feedback.Feedback;
 import tools.redstone.redstonetools.utils.WorldEditUtils;
@@ -18,6 +20,7 @@ import net.minecraft.text.Text;
 import java.util.ArrayList;
 import java.util.List;
 
+@AutoService(AbstractFeature.class)
 @Feature(command = "/minsel", description = "Removes all air-only layers from a selection", name = "Minimize Selection")
 public class MinSelectionFeature extends CommandFeature {
 

--- a/src/main/java/tools/redstone/redstonetools/features/commands/QuickTpFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/QuickTpFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -14,6 +16,7 @@ import net.minecraft.util.math.Vec3d;
 import static tools.redstone.redstonetools.features.arguments.serializers.BoolSerializer.bool;
 import static tools.redstone.redstonetools.features.arguments.serializers.FloatSerializer.floatArg;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Quick TP", description = "Teleports you in the direction you are looking.", command = "quicktp")
 public class QuickTpFeature extends CommandFeature {
     public static final Argument<Float> distance = Argument

--- a/src/main/java/tools/redstone/redstonetools/features/commands/RStackFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/RStackFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -23,7 +25,7 @@ import static tools.redstone.redstonetools.features.arguments.serializers.Intege
 import static tools.redstone.redstonetools.utils.DirectionUtils.directionToBlock;
 import static tools.redstone.redstonetools.utils.DirectionUtils.matchDirection;
 
-
+@AutoService(AbstractFeature.class)
 @Feature(name = "RStack", description = "Stacks with custom distance", command = "/rstack")
 public class RStackFeature extends CommandFeature {
     public static final Argument<Integer> count = Argument

--- a/src/main/java/tools/redstone/redstonetools/features/commands/SsBarrelFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/SsBarrelFeature.java
@@ -1,5 +1,7 @@
 package tools.redstone.redstonetools.features.commands;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
@@ -17,6 +19,7 @@ import java.util.Random;
 
 import static tools.redstone.redstonetools.features.arguments.serializers.IntegerSerializer.integer;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Signal Strength Barrel", description = "Creates a barrel with the specified signal strength.", command = "ss")
 public class SsBarrelFeature extends CommandFeature {
     private static final int BARREL_CONTAINER_SLOTS = 27;

--- a/src/main/java/tools/redstone/redstonetools/features/commands/update/UpdateFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/update/UpdateFeature.java
@@ -1,12 +1,15 @@
 package tools.redstone.redstonetools.features.commands.update;
 
+import com.google.auto.service.AutoService;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.server.command.ServerCommandSource;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.commands.CommandFeature;
 import tools.redstone.redstonetools.features.feedback.Feedback;
 import tools.redstone.redstonetools.utils.WorldEditUtils;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Update", description = "Forces block updates in the selected area.", command = "/update")
 public class UpdateFeature extends CommandFeature {
     @Override

--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
@@ -1,10 +1,10 @@
 package tools.redstone.redstonetools.features.toggleable;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
-import tools.redstone.redstonetools.features.arguments.Argument;
 
-import static tools.redstone.redstonetools.features.arguments.serializers.BoolSerializer.bool;
-
+@AutoService(AbstractFeature.class)
 @Feature(name = "Air Place", description = "Allows you to place blocks in the air.", command = "airplace")
 public class AirPlaceFeature extends ToggleableFeature {
 }

--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/AutoDustFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/AutoDustFeature.java
@@ -1,7 +1,10 @@
 package tools.redstone.redstonetools.features.toggleable;
 
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 
+@AutoService(AbstractFeature.class)
 @Feature(name = "Auto Dust", description = "Automatically places redstone on top of colored blocks.", command = "autodust")
 public class AutoDustFeature extends ToggleableFeature {
 }

--- a/src/main/java/tools/redstone/redstonetools/utils/ReflectionUtils.java
+++ b/src/main/java/tools/redstone/redstonetools/utils/ReflectionUtils.java
@@ -1,48 +1,45 @@
 package tools.redstone.redstonetools.utils;
 
+import com.google.inject.AbstractModule;
 import tools.redstone.redstonetools.features.AbstractFeature;
 import tools.redstone.redstonetools.features.Feature;
 import tools.redstone.redstonetools.features.arguments.Argument;
-import com.google.inject.AbstractModule;
-import org.reflections.Reflections;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ReflectionUtils {
-    private ReflectionUtils() { }
+    private static final ServiceLoader<AbstractModule> modulesLoader =
+            ServiceLoader.load(AbstractModule.class);
+    private static final ServiceLoader<AbstractFeature> featuresLoader =
+            ServiceLoader.load(AbstractFeature.class);
+    private static Set<? extends AbstractModule> modules;
+    private static Set<? extends AbstractFeature> features;
 
-
-    private static final Reflections reflections = new Reflections("tools.redstone.redstonetools");
+    private ReflectionUtils() {
+        throw new IllegalStateException("Utility class");
+    }
 
     public static Set<? extends AbstractModule> getModules() {
-        return getModuleClasses().stream()
-                .map(clazz -> {
-                    try {
-                        return clazz.getDeclaredConstructor().newInstance();
-                    } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
-                        throw new RuntimeException("Failed to instantiate module " + clazz.getName(), e);
-                    }
-                })
-                .collect(Collectors.toSet());
+        if (modules == null) {
+            modules = modulesLoader.stream()
+                    .map(ServiceLoader.Provider::get)
+                    .collect(Collectors.toSet());
+        }
+        return modules;
     }
 
-    private static Set<Class<? extends AbstractModule>> getModuleClasses() {
-        return getConcreteSubclasses(AbstractModule.class);
-    }
-
-    public static Set<Class<? extends AbstractFeature>> getFeatureClasses() {
-        return getConcreteSubclasses(AbstractFeature.class);
-    }
-
-    private static <T> Set<Class<? extends T>> getConcreteSubclasses(Class<T> clazz) {
-        return reflections.getSubTypesOf(clazz).stream()
-                .filter(subclass -> !Modifier.isAbstract(subclass.getModifiers()))
-                .collect(Collectors.toSet());
+    public static Set<? extends AbstractFeature> getFeatures() {
+        if (features == null) {
+            features = featuresLoader.stream()
+                    .map(ServiceLoader.Provider::get)
+                    .collect(Collectors.toSet());
+        }
+        return features;
     }
 
     public static List<Argument<?>> getArguments(Class<? extends AbstractFeature> featureClass) {
@@ -50,8 +47,8 @@ public class ReflectionUtils {
                 .filter(field -> Argument.class.isAssignableFrom(field.getType()))
                 .map(field -> {
                     if (!Modifier.isPublic(field.getModifiers())
-                     || !Modifier.isStatic(field.getModifiers())
-                     || !Modifier.isFinal(field.getModifiers())) {
+                            || !Modifier.isStatic(field.getModifiers())
+                            || !Modifier.isFinal(field.getModifiers())) {
                         throw new RuntimeException("Field " + field.getName() + " of feature " + featureClass.getName() + " is not public static final");
                     }
 


### PR DESCRIPTION
This shaves ~888kb (around half the size) off the final built jar, as well as speeds up the discovery process by roughly 633% (results may vary depending on hardware) from 343+12ms (reflections init + discovery) to 1+53ms (ServiceLoaders init + discovery).

The use of ServiceLoaders also allows other mods to provide service files to extend Redstone Tools without needing weird mixin/asm hacks to change our code.