### PR TITLE
Improve actions workflow.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -4,10 +4,6 @@ name: Build & test
 
 on:
   pull_request:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - main
 
 concurrency:
   group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,17 +21,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 10
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: temurin
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -49,7 +49,7 @@ jobs:
         run: ./gradlew build --no-daemon
 
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dev-artifacts
           path: build/libs/

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,31 +1,55 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+# Build Workflow
 
-name: Java CI with Gradle
+name: Build & test
 
 on:
   pull_request:
-    branches: ['main']
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
 
-permissions:
-  contents: read
+concurrency:
+  group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
+  cancel-in-progress: true
 
 jobs:
   build:
+    name: Build
+
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 10
+
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v2
         with:
-          java-version: '17'
-          distribution: 'adopt'
-      - name: Build with Gradle and run tests
-        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+          java-version: 17
+          distribution: temurin
+
+      - uses: actions/cache@v2
         with:
-          arguments: test
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            **/loom-cache
+            **/prebundled-jars
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Chmod Gradle
+        run: chmod +x ./gradlew
+
+      - name: Build
+        run: ./gradlew build --no-daemon
+
+      - name: Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dev-artifacts
+          path: build/libs/

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This currently adds a use to [`actions/cache@v3`](https://github.com/actions/cache) for faster build times, as well as
[`actions/upload-artifact@v3`](https://github.com/actions/upload-artifact) for easier testing of incoming PRs.

This also launches Gradle with `--no-daemon` which speeds it up just a bit which is pretty cool.

I'm noticing that I unknowingly removed
```yml
permissions:
  contents: read
```
and I'm unsure of what it's supposed to do, the [official documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) doesn't really do it justice.