### PR TITLE
Fixed //read default blockstate

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BinaryBlockReadFeature.java
@@ -13,6 +13,9 @@ import net.minecraft.block.RedstoneLampBlock;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.util.math.BlockPos;
+
+import java.util.Collections;
+
 import static tools.redstone.redstonetools.features.arguments.serializers.BlockStateArgumentSerializer.blockState;
 import static tools.redstone.redstonetools.features.arguments.serializers.BoolSerializer.bool;
 import static tools.redstone.redstonetools.features.arguments.serializers.IntegerSerializer.integer;
@@ -22,7 +25,9 @@ import static tools.redstone.redstonetools.features.arguments.serializers.Number
 @Feature(name = "Binary Block Read", description = "Interprets your WorldEdit selection as a binary number.", command = "/read")
 public class BinaryBlockReadFeature extends CommandFeature {
     private static final BlockStateArgument LIT_LAMP_ARG = new BlockStateArgument(
-            Blocks.REDSTONE_LAMP.getDefaultState().with(RedstoneLampBlock.LIT, true), null, null
+            Blocks.REDSTONE_LAMP.getDefaultState().with(RedstoneLampBlock.LIT, true),
+            Collections.singleton(RedstoneLampBlock.LIT),
+            null
     );
 
     public static final Argument<Integer> offset = Argument


### PR DESCRIPTION
Fixed bug #226

`BlockStateArgument` requires a set of properties to be passed upon creation. `LIT_LAMP_ARG` - default blockstate for //read command was created without this set and used afterwards.
I have added properties to the initialization of the default block state.