### PR TITLE
Big Dust Command

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
@@ -1,0 +1,41 @@
+package tools.redstone.redstonetools.features.commands;
+
+import com.google.auto.service.AutoService;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.server.command.ServerCommandSource;
+import tools.redstone.redstonetools.RedstoneToolsClient;
+import tools.redstone.redstonetools.features.AbstractFeature;
+import tools.redstone.redstonetools.features.Feature;
+import tools.redstone.redstonetools.features.arguments.Argument;
+import tools.redstone.redstonetools.features.feedback.Feedback;
+import tools.redstone.redstonetools.features.toggleable.BigDustFeature;
+
+import static tools.redstone.redstonetools.features.arguments.serializers.FloatSerializer.floatArg;
+
+@AutoService(AbstractFeature.class)
+@Feature(name = "Big Dust", description = "Change the size of redstone's hitbox.", command = "bigdust")
+public class BigDustHeightFeature extends CommandFeature {
+
+    public float customHeight = 8.0f;
+
+    public static final Argument<Float> height = Argument
+            .ofType(floatArg(1.0f, 16.0f));
+
+    @Override
+    protected Feedback execute(ServerCommandSource source) throws CommandSyntaxException {
+        customHeight = height.getValue();
+
+        BigDustFeature bigDustFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustFeature.class);
+        if (!bigDustFeature.isEnabled()) {
+            bigDustFeature.enable(source);
+        }
+
+        double heightInBlocks = customHeight/16.0;
+
+        if (heightInBlocks == 1) {
+            return Feedback.success("Redstone dust hitbox height set to " + heightInBlocks + " block.");
+        }
+        return Feedback.success("Redstone dust hitbox height set to " + heightInBlocks + " blocks.");
+    }
+
+}

--- a/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
@@ -16,7 +16,7 @@ import static tools.redstone.redstonetools.features.arguments.serializers.Intege
 @Feature(name = "Big Dust", description = "Change the size of redstone's hitbox.", command = "bigdust")
 public class BigDustHeightFeature extends CommandFeature {
 
-    public double customHeight = 1.0f;
+    public int customHeight = 1;
 
     public static final Argument<Integer> height = Argument
             .ofType(integer(1, 16));

--- a/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
@@ -10,16 +10,16 @@ import tools.redstone.redstonetools.features.arguments.Argument;
 import tools.redstone.redstonetools.features.feedback.Feedback;
 import tools.redstone.redstonetools.features.toggleable.BigDustFeature;
 
-import static tools.redstone.redstonetools.features.arguments.serializers.FloatSerializer.floatArg;
+import static tools.redstone.redstonetools.features.arguments.serializers.IntegerSerializer.integer;
 
 @AutoService(AbstractFeature.class)
 @Feature(name = "Big Dust", description = "Change the size of redstone's hitbox.", command = "bigdust")
 public class BigDustHeightFeature extends CommandFeature {
 
-    public float customHeight = 8.0f;
+    public double customHeight = 1.0f;
 
-    public static final Argument<Float> height = Argument
-            .ofType(floatArg(1.0f, 16.0f));
+    public static final Argument<Integer> height = Argument
+            .ofType(integer(1, 16));
 
     @Override
     protected Feedback execute(ServerCommandSource source) throws CommandSyntaxException {
@@ -33,7 +33,7 @@ public class BigDustHeightFeature extends CommandFeature {
         double heightInBlocks = customHeight/16.0;
 
         if (heightInBlocks == 1) {
-            return Feedback.success("Redstone dust hitbox height set to " + heightInBlocks + " block.");
+            return Feedback.success("Redstone dust hitbox height set to 1 block.");
         }
         return Feedback.success("Redstone dust hitbox height set to " + heightInBlocks + " blocks.");
     }

--- a/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/BigDustHeightFeature.java
@@ -18,12 +18,12 @@ public class BigDustHeightFeature extends CommandFeature {
 
     public int customHeight = 1;
 
-    public static final Argument<Integer> height = Argument
+    public static final Argument<Integer> heightPixels = Argument
             .ofType(integer(1, 16));
 
     @Override
     protected Feedback execute(ServerCommandSource source) throws CommandSyntaxException {
-        customHeight = height.getValue();
+        customHeight = heightPixels.getValue();
 
         BigDustFeature bigDustFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustFeature.class);
         if (!bigDustFeature.isEnabled()) {
@@ -32,10 +32,7 @@ public class BigDustHeightFeature extends CommandFeature {
 
         double heightInBlocks = customHeight/16.0;
 
-        if (heightInBlocks == 1) {
-            return Feedback.success("Redstone dust hitbox height set to 1 block.");
-        }
-        return Feedback.success("Redstone dust hitbox height set to " + heightInBlocks + " blocks.");
+        return Feedback.success("Redstone dust hitbox height set to {} block(s).", heightInBlocks);
     }
 
 }

--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/BigDustFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/BigDustFeature.java
@@ -1,0 +1,10 @@
+package tools.redstone.redstonetools.features.toggleable;
+
+import com.google.auto.service.AutoService;
+import tools.redstone.redstonetools.features.AbstractFeature;
+import tools.redstone.redstonetools.features.Feature;
+
+@AutoService(AbstractFeature.class)
+@Feature(name = "Big Dust", description = "Change the size of redstone's hitbox.", command = "bigdust")
+public class BigDustFeature extends ToggleableFeature {
+}

--- a/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
+++ b/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
@@ -1,0 +1,46 @@
+package tools.redstone.redstonetools.mixin.blocks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.RedstoneWireBlock;
+import net.minecraft.block.ShapeContext;
+import net.minecraft.state.property.IntProperty;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.*;
+import tools.redstone.redstonetools.RedstoneToolsClient;
+import tools.redstone.redstonetools.features.commands.BigDustHeightFeature;
+import tools.redstone.redstonetools.features.toggleable.BigDustFeature;
+
+import java.util.Map;
+
+@Pseudo
+@Mixin(RedstoneWireBlock.class)
+public class RedstoneHitboxMixin {
+
+    @Final
+    @Shadow
+    private static Map<BlockState, VoxelShape> SHAPES;
+
+    @Final
+    @Shadow
+    public static IntProperty POWER;
+
+    /**
+     * @author JayMensink
+     * @reason Issue #279: Option to make redstone hitbox bigger
+     */
+    @Overwrite
+    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+        BigDustFeature bigDustFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustFeature.class);
+        BigDustHeightFeature bigDustHeightFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustHeightFeature.class);
+
+        if (bigDustFeature.isEnabled()) {
+            return Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, bigDustHeightFeature.customHeight, 16.0);
+        }
+
+        return SHAPES.get(state.with(POWER, 0));
+    }
+
+}

--- a/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
+++ b/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
@@ -4,43 +4,29 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.RedstoneWireBlock;
 import net.minecraft.block.ShapeContext;
-import net.minecraft.state.property.IntProperty;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import org.spongepowered.asm.mixin.*;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import tools.redstone.redstonetools.RedstoneToolsClient;
 import tools.redstone.redstonetools.features.commands.BigDustHeightFeature;
 import tools.redstone.redstonetools.features.toggleable.BigDustFeature;
-
-import java.util.Map;
 
 @Pseudo
 @Mixin(RedstoneWireBlock.class)
 public class RedstoneHitboxMixin {
 
-    @Final
-    @Shadow
-    private static Map<BlockState, VoxelShape> SHAPES;
-
-    @Final
-    @Shadow
-    public static IntProperty POWER;
-
-    /**
-     * @author JayMensink
-     * @reason Issue #279: Option to make redstone hitbox bigger
-     */
-    @Overwrite
-    public VoxelShape getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context) {
+    @Inject(method="getOutlineShape", at = @At("HEAD"), cancellable = true)
+    public void getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
         BigDustFeature bigDustFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustFeature.class);
         BigDustHeightFeature bigDustHeightFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustHeightFeature.class);
 
         if (bigDustFeature.isEnabled()) {
-            return Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, bigDustHeightFeature.customHeight, 16.0);
+            cir.setReturnValue( Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, bigDustHeightFeature.customHeight, 16.0) );
         }
-
-        return SHAPES.get(state.with(POWER, 0));
     }
 
 }

--- a/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
+++ b/src/main/java/tools/redstone/redstonetools/mixin/blocks/RedstoneHitboxMixin.java
@@ -15,17 +15,27 @@ import tools.redstone.redstonetools.RedstoneToolsClient;
 import tools.redstone.redstonetools.features.commands.BigDustHeightFeature;
 import tools.redstone.redstonetools.features.toggleable.BigDustFeature;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Pseudo
 @Mixin(RedstoneWireBlock.class)
 public class RedstoneHitboxMixin {
+
+    private static final Map<Integer, VoxelShape> SHAPES = new HashMap<>();
 
     @Inject(method="getOutlineShape", at = @At("HEAD"), cancellable = true)
     public void getOutlineShape(BlockState state, BlockView world, BlockPos pos, ShapeContext context, CallbackInfoReturnable<VoxelShape> cir) {
         BigDustFeature bigDustFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustFeature.class);
         BigDustHeightFeature bigDustHeightFeature = RedstoneToolsClient.INJECTOR.getInstance(BigDustHeightFeature.class);
-
         if (bigDustFeature.isEnabled()) {
-            cir.setReturnValue( Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, bigDustHeightFeature.customHeight, 16.0) );
+            cir.setReturnValue( SHAPES.get(bigDustHeightFeature.customHeight) );
+        }
+    }
+
+    static {
+        for (int i = 1; i <= 16; i++) {
+            SHAPES.put(i, Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, i, 16.0) );
         }
     }
 

--- a/src/main/resources/redstonetools.mixins.json
+++ b/src/main/resources/redstonetools.mixins.json
@@ -7,6 +7,7 @@
     "defaultRequire": 1
   },
   "mixins": [
+    "blocks.RedstoneHitboxMixin",
     "features.AirPlaceServerMixin",
     "features.AutoDustMixin",
     "features.CopyStateMixin",


### PR DESCRIPTION
This command allows the user to change the hitbox of redstone dust.

/bigdust: Toggles the Big Dust feature.
/bigdust \<height>: Sets the height of the redstone dust hitbox to \<height> measured in Minecraft pixels.
1 = carpet, 2 = snow layer, 8 = slab, 16 = full block.

Issue #279 