### PR TITLE
Internal Feedback Improvements

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/features/AbstractFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/AbstractFeature.java
@@ -3,6 +3,7 @@ package tools.redstone.redstonetools.features;
 import com.mojang.brigadier.CommandDispatcher;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.minecraft.server.command.ServerCommandSource;
+import tools.redstone.redstonetools.RedstoneToolsClient;
 
 public abstract class AbstractFeature {
     private final Feature feature;
@@ -31,6 +32,8 @@ public abstract class AbstractFeature {
      * Register this feature.
      */
     public void register() {
+        RedstoneToolsClient.LOGGER.info("Registering and initializing feature " + getName());
+
         CommandRegistrationCallback.EVENT.register(this::registerCommands);
     }
 

--- a/src/main/java/tools/redstone/redstonetools/features/arguments/serializers/BlockStateArgumentSerializer.java
+++ b/src/main/java/tools/redstone/redstonetools/features/arguments/serializers/BlockStateArgumentSerializer.java
@@ -2,9 +2,13 @@ package tools.redstone.redstonetools.features.arguments.serializers;
 
 import com.mojang.brigadier.StringReader;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import net.minecraft.block.BlockState;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.command.argument.BlockStateArgumentType;
+import net.minecraft.nbt.NbtCompound;
 import net.minecraft.util.registry.Registry;
+
+import java.util.HashSet;
 
 public class BlockStateArgumentSerializer extends BrigadierSerializer<BlockStateArgument, String> {
 
@@ -16,6 +20,10 @@ public class BlockStateArgumentSerializer extends BrigadierSerializer<BlockState
 
     public static BlockStateArgumentSerializer blockState() {
         return INSTANCE;
+    }
+
+    public static BlockStateArgument toArgument(BlockState blockState) {
+        return new BlockStateArgument(blockState, new HashSet<>(blockState.getProperties()), new NbtCompound());
     }
 
     @Override

--- a/src/main/java/tools/redstone/redstonetools/features/arguments/serializers/EnumSerializer.java
+++ b/src/main/java/tools/redstone/redstonetools/features/arguments/serializers/EnumSerializer.java
@@ -14,6 +14,10 @@ import java.util.concurrent.CompletableFuture;
 public abstract class EnumSerializer<T extends Enum<T>>
         extends TypeSerializer<T, String> {
 
+    public static <T extends Enum<T>> EnumSerializer<T> of(Class<T> tClass) {
+        return new EnumSerializer<>(tClass) { };
+    }
+
     protected EnumSerializer(Class<T> clazz) {
         super(clazz);
     }

--- a/src/main/java/tools/redstone/redstonetools/features/feedback/AbstractFeedbackSender.java
+++ b/src/main/java/tools/redstone/redstonetools/features/feedback/AbstractFeedbackSender.java
@@ -3,5 +3,8 @@ package tools.redstone.redstonetools.features.feedback;
 import net.minecraft.server.command.ServerCommandSource;
 
 public abstract class AbstractFeedbackSender {
+
+    public abstract void sendIntermediateFeedback(ServerCommandSource source, Feedback feedback);
     public abstract void sendFeedback(ServerCommandSource source, Feedback feedback);
+
 }

--- a/src/main/java/tools/redstone/redstonetools/features/feedback/Feedback.java
+++ b/src/main/java/tools/redstone/redstonetools/features/feedback/Feedback.java
@@ -1,29 +1,72 @@
 package tools.redstone.redstonetools.features.feedback;
 
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.server.command.ServerCommandSource;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import tools.redstone.redstonetools.RedstoneToolsClient;
 
 import javax.annotation.Nullable;
 
+import static tools.redstone.redstonetools.utils.TextUtils.format;
+import static tools.redstone.redstonetools.utils.TextUtils.join;
+
 public abstract class Feedback {
-    private final @Nullable String message;
+
+    private static final MutableText PREFIX = new LiteralText("%s[%sRST%s]%s ".formatted(Formatting.GRAY, Formatting.RED, Formatting.GRAY, Formatting.RESET));
+
+    private final @Nullable MutableText message;
     private final @Nullable Object[] values;
 
-    protected Feedback(@Nullable String message, @Nullable Object... values) {
-        this.message = message;
+    protected Feedback(@Nullable Text message, @Nullable Object... values) {
+        this.message = message instanceof MutableText mt ? mt :
+                (message == null ? null : message.copy());
         this.values = values;
     }
 
-    private String formatMessage(String message) {
-        return String.format("%s[%sRST%s]%s ", Formatting.GRAY, Formatting.RED, Formatting.GRAY, Formatting.RESET) + message;
+    private MutableText formatMessage(MutableText message) {
+        return join(PREFIX, message);
     }
 
-    public final String getMessage() {
-        if (message != null) {
-            String sentMessage = message;
-            for (Object value : values) {
-                sentMessage = sentMessage.replaceFirst("\\{\\}", Formatting.RED + value.toString() + getFormatting());
-            }
+    /**
+     * Manually send this feedback as an intermediate message to the recipient.
+     *
+     * @param recipient The recipient.
+     */
+    public void sendIntermediate(ServerCommandSource recipient) {
+        RedstoneToolsClient.INJECTOR
+                .getInstance(FeedbackSender.class)
+                .sendIntermediateFeedback(recipient, this);
+    }
 
+    public void sendIntermediate(CommandContext<ServerCommandSource> context) {
+        sendIntermediate(context.getSource());
+    }
+
+    /**
+     * Manually send this feedback as an intermediate message to the recipient.
+     *
+     * @param recipient The recipient.
+     * @return The command status code.
+     */
+    public int send(ServerCommandSource recipient) {
+        RedstoneToolsClient.INJECTOR
+                .getInstance(FeedbackSender.class)
+                .sendFeedback(recipient, this);
+
+        return getType().getCode();
+    }
+
+    public int send(CommandContext<ServerCommandSource> context) {
+        return send(context.getSource());
+    }
+
+    public final MutableText getMessage() {
+        if (message != null) {
+            MutableText sentMessage = format(message, values);
             return formatMessage(sentMessage);
         } else {
             return formatMessage(getDefaultMessage());
@@ -31,14 +74,14 @@ public abstract class Feedback {
     }
 
     public abstract Formatting getFormatting();
-    public abstract String getDefaultMessage();
+    public abstract MutableText getDefaultMessage();
     public abstract FeedbackType getType();
 
     public static None none() {
         return new None();
     }
 
-    private static class None extends Feedback {
+    public static class None extends Feedback {
         public None() {
             super(null);
         }
@@ -49,8 +92,8 @@ public abstract class Feedback {
         }
 
         @Override
-        public String getDefaultMessage() {
-            return "";
+        public MutableText getDefaultMessage() {
+            return new LiteralText("");
         }
 
         @Override
@@ -59,12 +102,16 @@ public abstract class Feedback {
         }
     }
 
-    public static Success success(@Nullable String message, @Nullable Object... values) {
+    public static Success success(@Nullable Text message, @Nullable Object... values) {
         return new Success(message, values);
     }
 
-    private static class Success extends Feedback {
-        public Success(@Nullable String message, @Nullable Object... values) {
+    public static Success success(@Nullable String message, @Nullable Object... values) {
+        return new Success(Text.of(message), values);
+    }
+
+    public static class Success extends Feedback {
+        public Success(@Nullable Text message, @Nullable Object... values) {
             super(message, values);
         }
 
@@ -74,8 +121,8 @@ public abstract class Feedback {
         }
 
         @Override
-        public String getDefaultMessage() {
-            return "Success";
+        public MutableText getDefaultMessage() {
+            return new LiteralText("Success").setStyle(Style.EMPTY.withFormatting(Formatting.GREEN));
         }
 
         @Override
@@ -84,12 +131,16 @@ public abstract class Feedback {
         }
     }
 
-    public static Warning warning(@Nullable String message, @Nullable Object... values) {
+    public static Warning warning(@Nullable Text message, @Nullable Object... values) {
         return new Warning(message, values);
     }
 
-    private static class Warning extends Feedback {
-        public Warning(@Nullable String message, @Nullable Object... values) {
+    public static Warning warning(@Nullable String message, @Nullable Object... values) {
+        return new Warning(Text.of(message), values);
+    }
+
+    public static class Warning extends Feedback {
+        public Warning(@Nullable Text message, @Nullable Object... values) {
             super(message, values);
         }
 
@@ -99,8 +150,8 @@ public abstract class Feedback {
         }
 
         @Override
-        public String getDefaultMessage() {
-            return "Warning";
+        public MutableText getDefaultMessage() {
+            return new LiteralText("Warning").setStyle(Style.EMPTY.withFormatting(Formatting.YELLOW));
         }
 
         @Override
@@ -110,11 +161,15 @@ public abstract class Feedback {
     }
 
     public static Error error(@Nullable String message, @Nullable Object... values) {
+        return new Error(Text.of(message), values);
+    }
+
+    public static Error error(@Nullable Text message, @Nullable Object... values) {
         return new Error(message, values);
     }
 
-    private static class Error extends Feedback {
-        public Error(@Nullable String message, @Nullable Object... values) {
+    public static class Error extends Feedback {
+        public Error(@Nullable Text message, @Nullable Object... values) {
             super(message, values);
         }
 
@@ -124,8 +179,8 @@ public abstract class Feedback {
         }
 
         @Override
-        public String getDefaultMessage() {
-            return "Error";
+        public MutableText getDefaultMessage() {
+            return new LiteralText("Error").setStyle(Style.EMPTY.withFormatting(Formatting.RED));
         }
 
         @Override
@@ -135,11 +190,15 @@ public abstract class Feedback {
     }
 
     public static InvalidUsage invalidUsage(@Nullable String message, @Nullable Object... values) {
+        return new InvalidUsage(Text.of(message), values);
+    }
+
+    public static InvalidUsage invalidUsage(@Nullable Text message, @Nullable Object... values) {
         return new InvalidUsage(message, values);
     }
 
-    private static class InvalidUsage extends Feedback {
-        public InvalidUsage(@Nullable String message, @Nullable Object... values) {
+    public static class InvalidUsage extends Feedback {
+        public InvalidUsage(@Nullable Text message, @Nullable Object... values) {
             super(message, values);
         }
 
@@ -149,8 +208,8 @@ public abstract class Feedback {
         }
 
         @Override
-        public String getDefaultMessage() {
-            return "Invalid usage";
+        public MutableText getDefaultMessage() {
+            return new LiteralText("Invalid usage").setStyle(Style.EMPTY.withFormatting(Formatting.RED));
         }
 
         @Override

--- a/src/main/java/tools/redstone/redstonetools/features/feedback/FeedbackSender.java
+++ b/src/main/java/tools/redstone/redstonetools/features/feedback/FeedbackSender.java
@@ -1,19 +1,31 @@
 package tools.redstone.redstonetools.features.feedback;
 
+import net.minecraft.command.CommandSource;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.Style;
+import net.minecraft.text.Texts;
 
 import javax.inject.Singleton;
 
 @Singleton
 public class FeedbackSender extends AbstractFeedbackSender {
+
+    @Override
+    public void sendIntermediateFeedback(ServerCommandSource source, Feedback feedback) {
+        sendFeedback(source, feedback);
+    }
+
     @Override
     public void sendFeedback(ServerCommandSource source, Feedback feedback) {
         if (feedback.getType() == FeedbackType.NONE) {
             return;
         }
 
-        source.sendFeedback(new LiteralText(feedback.getMessage())
-                .formatted(feedback.getFormatting()), false);
+        source.sendFeedback(
+                Texts.setStyleIfAbsent(feedback.getMessage(),
+                        Style.EMPTY.withFormatting(feedback.getFormatting())
+        ), false);
     }
+
 }

--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/ToggleableFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/ToggleableFeature.java
@@ -30,33 +30,22 @@ public abstract class ToggleableFeature extends AbstractFeature {
         return enabled;
     }
 
-    public int toggle(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        return toggle(context.getSource());
-    }
+    private int toggle(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+        enabled = !enabled;
 
-    public int toggle(ServerCommandSource source) throws CommandSyntaxException {
-        return !enabled ? enable(source) : disable(source);
+        return enabled ? onEnable(context.getSource()) : onDisable(context.getSource());
     }
 
     //TODO: these need to be replaced when the sendMessage util gets made.
-    public int enable(ServerCommandSource source) throws CommandSyntaxException {
-        enabled = true;
+    protected int onEnable(ServerCommandSource source) throws CommandSyntaxException {
         INJECTOR.getInstance(FeedbackSender.class).sendFeedback(source, Feedback.success(info.name() + " has been enabled."));
+
         return 0;
     }
 
-    public int enable(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        return enable(context.getSource());
-    }
-
-    public int disable(ServerCommandSource source) throws CommandSyntaxException {
-        enabled = false;
+    protected int onDisable(ServerCommandSource source) throws CommandSyntaxException {
         INJECTOR.getInstance(FeedbackSender.class).sendFeedback(source, Feedback.success(info.name() + " has been disabled."));
+
         return 0;
     }
-
-    public int disable(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
-        return disable(context.getSource());
-    }
-
 }

--- a/src/main/java/tools/redstone/redstonetools/macros/gui/screen/MacroEditScreen.java
+++ b/src/main/java/tools/redstone/redstonetools/macros/gui/screen/MacroEditScreen.java
@@ -24,6 +24,7 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import tools.redstone.redstonetools.utils.KeyBindingUtils;
 
 import java.util.List;
 
@@ -92,6 +93,7 @@ public class MacroEditScreen extends GameOptionsScreen {
         Key keyCode = macro.getKey();
         Text text = keyCode.getLocalizedText();
         if (keyCode == InputUtil.UNKNOWN_KEY) text = Text.of("");
+        if ( KeyBindingUtils.isKeyAlreadyBound(keyCode) ) { text = new LiteralText(text.getString()).formatted(Formatting.RED); }
 
         keyBindButton = new ButtonWidget(this.width / 2 + 26, 55, 75, 20, text, (button) -> {
             detectingKeycodeKey = true;
@@ -244,6 +246,7 @@ public class MacroEditScreen extends GameOptionsScreen {
             detectingKeycodeKey = false;
             Text text = key.getLocalizedText();
             if (key == InputUtil.UNKNOWN_KEY) text = Text.of("");
+            if ( KeyBindingUtils.isKeyAlreadyBound(key) ) { text = new LiteralText(text.getString()).formatted(Formatting.RED); }
 
             keyBindButton.setMessage(text);
             macro.setKey(key);

--- a/src/main/java/tools/redstone/redstonetools/macros/gui/screen/MacroEditScreen.java
+++ b/src/main/java/tools/redstone/redstonetools/macros/gui/screen/MacroEditScreen.java
@@ -24,7 +24,6 @@ import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
-import tools.redstone.redstonetools.utils.KeyBindingUtils;
 
 import java.util.List;
 
@@ -93,7 +92,6 @@ public class MacroEditScreen extends GameOptionsScreen {
         Key keyCode = macro.getKey();
         Text text = keyCode.getLocalizedText();
         if (keyCode == InputUtil.UNKNOWN_KEY) text = Text.of("");
-        if ( KeyBindingUtils.isKeyAlreadyBound(keyCode) ) { text = new LiteralText(text.getString()).formatted(Formatting.RED); }
 
         keyBindButton = new ButtonWidget(this.width / 2 + 26, 55, 75, 20, text, (button) -> {
             detectingKeycodeKey = true;
@@ -246,7 +244,6 @@ public class MacroEditScreen extends GameOptionsScreen {
             detectingKeycodeKey = false;
             Text text = key.getLocalizedText();
             if (key == InputUtil.UNKNOWN_KEY) text = Text.of("");
-            if ( KeyBindingUtils.isKeyAlreadyBound(key) ) { text = new LiteralText(text.getString()).formatted(Formatting.RED); }
 
             keyBindButton.setMessage(text);
             macro.setKey(key);

--- a/src/main/java/tools/redstone/redstonetools/utils/TextUtils.java
+++ b/src/main/java/tools/redstone/redstonetools/utils/TextUtils.java
@@ -1,0 +1,89 @@
+package tools.redstone.redstonetools.utils;
+
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Formatting;
+
+public class TextUtils {
+
+    private static class SharedInt {
+        public int value;
+    }
+
+    /** Joins all given text components without a seperator. */
+    public static MutableText join(MutableText... texts) {
+        MutableText text = new LiteralText("");
+        for (Text tx : texts) {
+            text.append(tx);
+        }
+
+        return text;
+    }
+
+    /** Replace all literal placeholders in the given text with the provided values. */
+    public static MutableText format(Text text, Object... values) {
+        return format0(text, new SharedInt(), values);
+    }
+
+    private static String formatStringShared(String str, SharedInt paramIndex, Object... values) {
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < str.length(); i++) {
+            char c = str.charAt(i);
+            if (c == '\\' && i != str.length() - 1 && str.charAt(i + 1) == '{') {
+                // escaped placeholder, dont handle
+                i++;
+                b.append('{');
+            } else if (c == '{') {
+                // format placeholder
+                i++;
+
+                boolean formatPlaceholder = true;
+                if (str.charAt(i) == '~') {
+                    formatPlaceholder = false;
+                    i++;
+                }
+
+                if (str.charAt(i) == '}') {
+                    if (formatPlaceholder)
+                        b.append(Formatting.RED);
+
+                    // no specific index provided, use
+                    // the shared paramIndex
+                    b.append(values[paramIndex.value++]);
+
+                    if (formatPlaceholder)
+                        b.append(Formatting.RESET);
+                } else {
+                    // todo: add ability to specify a specific
+                    //  value like {IDX}
+                }
+            } else {
+                // append character
+                b.append(c);
+            }
+        }
+
+        return b.toString();
+    }
+
+    private static MutableText format0(Text text, SharedInt paramIndex, Object... values) {
+        MutableText result;
+
+        if (text instanceof LiteralText literalText) {
+            // format string
+            result = new LiteralText(formatStringShared(literalText.getRawString(),
+                    paramIndex, values));
+        } else /* unsupported type */ {
+            return text.copy();
+        }
+
+        // format children
+        for (Text child : text.getSiblings()) {
+            result.append(format0(child, paramIndex, values));
+        }
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
No breaking changes to the API.

Feedback now uses and accepts text components for more advanced/customizable formatting. 

You can now send intermediate feedback like warnings with `void Feedback#sendIntermediate` (example: `Feedback.warning("abc {}", abc).sendIntermediate(source)`) and send feedback as the final feedback using `int Feedback#send` when creating commands with Brigadier. The method returns the feedback's status code to be reported to Brigadier. (example: `return Feedback.error("abc {}", abc).send(source)`)

Placeholders are formatted as red by default, but by replacing the default `{}` with `{~}` you can disable the formatting of the placeholder.

I need this for a couple improvements I've been assigned to. At least, it would make it much less painful.