### PR TITLE
use SHsuperCM/FletchingTable so you dont have to specify mixins 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
 	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
 	id 'com.github.johnrengelman.shadow' version '8.+'
+	id "io.shcm.shsupercm.fabric.fletchingtable" version "1.6"
+
 }
 
 sourceCompatibility = JavaVersion.VERSION_17
@@ -102,4 +104,8 @@ publishing {
 		// The repositories here will be used for publishing your artifact, not for
 		// retrieving dependencies.
 	}
+}
+
+fletchingTable {
+	defaultMixinEnvironment = "auto" //default, can be either "none", "auto", "mixins", "client", "server"
 }

--- a/src/main/java/tools/redstone/redstonetools/mixin/accessors/WorldRendererAccessor.java
+++ b/src/main/java/tools/redstone/redstonetools/mixin/accessors/WorldRendererAccessor.java
@@ -1,5 +1,6 @@
 package tools.redstone.redstonetools.mixin.accessors;
 
+import io.shcm.shsupercm.fabric.fletchingtable.api.MixinEnvironment;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.WorldRenderer;

--- a/src/main/java/tools/redstone/redstonetools/mixin/features/ItemBindMixin.java
+++ b/src/main/java/tools/redstone/redstonetools/mixin/features/ItemBindMixin.java
@@ -1,5 +1,6 @@
 package tools.redstone.redstonetools.mixin.features;
 
+import io.shcm.shsupercm.fabric.fletchingtable.api.MixinEnvironment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.entity.player.PlayerEntity;
@@ -26,7 +27,7 @@ import static tools.redstone.redstonetools.RedstoneToolsClient.INJECTOR;
 
 
 public abstract class ItemBindMixin {
-
+    @MixinEnvironment()
     @Mixin(ItemStack.class)
     private abstract static class ItemStackMixin {
 
@@ -58,7 +59,7 @@ public abstract class ItemBindMixin {
         }
     }
 
-
+    @MixinEnvironment()
     @Mixin(ClientPlayNetworkHandler.class)
     private abstract static class NetworkHandlerMixin {
 

--- a/src/main/resources/redstonetools.mixins.json
+++ b/src/main/resources/redstonetools.mixins.json
@@ -5,25 +5,5 @@
   "compatibilityLevel": "JAVA_17",
   "injectors": {
     "defaultRequire": 1
-  },
-  "mixins": [
-    "blocks.RedstoneHitboxMixin",
-    "features.AirPlaceServerMixin",
-    "features.AutoDustMixin",
-    "features.CopyStateMixin",
-    "features.ItemBindMixin$ItemStackMixin",
-    "gamerules.DoContainerDropsMixin"
-  ],
-  "client": [
-    "accessors.MinecraftClientAccessor",
-    "accessors.WorldRendererAccessor",
-    "features.AirPlaceClientMixin",
-    "features.ItemBindMixin$NetworkHandlerMixin",
-    "macros.AddMacroButtonMixin",
-    "macros.InitializeMacroManagerMixin",
-    "macros.KeyBindingMixinImpl",
-    "macros.autocomplete.ClientPlayerEntityMixinImpl",
-    "macros.autocomplete.CommandSuggestorMixin",
-    "update.CheckUpdateMixin"
-  ]
+  }
 }


### PR DESCRIPTION
- removes all specified mixins from redstonetools.mixins.json
- adds SHsuperCM/FletchingTable as a plugin


specifically, in ItemBindMixin.java i added the @MixinEnvironment decorator because without it, it doesn't recognize either of the classes as mixins. my best guess is its because there are two mixins with different environments in the same file* so it gets confused 