### PR TITLE
fix: solve visual bug in air place highlight

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
@@ -88,11 +88,10 @@ public class AirPlaceFeature extends ToggleableFeature {
             if (!canAirPlace(client.player))
                 return true;
 
-            HitResult hitResult = findAirPlacePosition(client);
+            BlockHitResult hitResult = findAirPlaceBlockHit(client.player);
             if (hitResult == null)
                 return true;
-            Vec3d pos = hitResult.getPos();
-            BlockPos blockPos = new BlockPos((int) pos.x, (int) pos.y, (int) pos.z);
+            BlockPos blockPos = hitResult.getBlockPos();
 
             BlockState blockState = ItemUtils.getUseState(client.player,
                     ItemUtils.getMainItem(client.player),

--- a/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
@@ -47,15 +47,6 @@ public class AirPlaceFeature extends ToggleableFeature {
         return true;
     }
 
-    public static HitResult findAirPlacePosition(MinecraftClient client) {
-        if (client.player == null)
-            return null;
-        ClientPlayerEntity player = client.player;
-
-        float reach = AirPlaceFeature.reach.getValue();
-        return player.raycast(reach, 0, false);
-    }
-
     public static BlockHitResult findAirPlaceBlockHit(PlayerEntity playerEntity) {
         var hit = RaycastUtils.rayCastFromEye(playerEntity, reach.getValue());
         return new BlockHitResult(hit.getPos(), hit.getSide(), hit.getBlockPos(), false);


### PR DESCRIPTION
This is a bug that the 1.20.4 version of this mod had for a long time and was preventing it from actually releasing (at least it seemed to), and i also wanted this bug fixed so I fixed it myself. The issue was that there was a discrepancy of the function that was used between when you actually place a block and when the hightlight is rendered so I made sure both use the same method and the issue is fixed.
![imagem](https://github.com/RedstoneTools/redstonetools-mod/assets/92828847/9ee86c3e-2b2e-4818-8b69-d7c3d0e7b642)
