### PR TITLE
[PORT] - Add Minecraft 26.2 target

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -22,7 +22,7 @@ jobs:
             - name: Setup JDK
               uses: actions/setup-java@v4
               with:
-                  java-version: 21
+                  java-version: 25
                   distribution: 'microsoft'
 
             - name: Setup Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ dependencies {
 		implementation("fi.dy.masa.malilib:malilib-fabric-${project.property("malilib_version")}")
 		implementation("net.kr1v:malilib-api:${project.property("malilib_api_version")}")
 	}
-	annotationProcessor("net.kr1v:malilib-api-processor:1.0.0")
+	"clientAnnotationProcessor"("net.kr1v:malilib-api-processor:1.0.0")
 }
 
 configurations.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ archives_base_name = redstonetools
 loader_version=0.18.4
 mod_version = 3.4.0
 
-loomx.loom_version = 1.16-SNAPSHOT
+loomx.loom_version = 1.17-SNAPSHOT
 loomx.loom_remap_plugin = net.fabricmc.fabric-loom-remap
 loomx.loom_unobf_plugin = net.fabricmc.fabric-loom

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ stonecutter {
     centralScript = "build.gradle.kts"
 
     create(rootProject) {
-        versions("1.21.4", "1.21.5", "1.21.8", "1.21.10", "1.21.11", "26.1.2")
+        versions("1.21.4", "1.21.5", "1.21.8", "1.21.10", "1.21.11", "26.1.2", "26.2")
 		vcsVersion = "1.21.11"
     }
 }

--- a/src/client/java/tools/redstone/redstonetools/config/option/ConfigMacro.java
+++ b/src/client/java/tools/redstone/redstonetools/config/option/ConfigMacro.java
@@ -116,7 +116,8 @@ public class ConfigMacro extends CustomConfigBase<ConfigMacro, Void> implements 
 			@Override
 			protected boolean onMouseClickedImpl(/*? if >=1.21.10 {*/net.minecraft.client.input.MouseButtonEvent click, boolean doubleClick/*? } else {*//*int mouseX, int mouseY, int mouseButton*//*? }*/) {
 				super.onMouseClickedImpl(/*? if >=1.21.10 {*/click, doubleClick/*? } else {*//*mouseX, mouseY, mouseButton*//*? }*/);
-				GuiBase.openGui(new GuiMacroEditor(Component.nullToEmpty(configMacro.macroName), configMacro, Minecraft.getInstance().screen));
+				GuiBase.openGui(new GuiMacroEditor(Component.nullToEmpty(configMacro.macroName), configMacro,/*? if <26.2 {*/Minecraft.getInstance().screen/*?} else {*/ /*Minecraft.getInstance().gui.screen()*//*?}*/
+				));
 				return true;
 			}
 		});

--- a/src/client/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
+++ b/src/client/java/tools/redstone/redstonetools/features/toggleable/AirPlaceFeature.java
@@ -95,6 +95,91 @@ public class AirPlaceFeature extends ClientToggleableFeature {
 		return new BlockHitResult(hit.getLocation(), hit.getDirection(), hit.getBlockPos(), false);
 	}
 
+	//? if <26.1 {
+	private static void renderBlockOutline(WorldRenderContext context, Minecraft client, BlockPos blockPos, BlockState blockState) {
+	//? } else
+	//private static void renderBlockOutline(LevelRenderContext context, Minecraft client, BlockPos blockPos, BlockState blockState) {
+		//? if <26.2 {
+		Camera camera = client.gameRenderer.getMainCamera();
+		 //?} else
+		//Camera camera = client.gameRenderer.mainCamera();
+		Vec3 camPos = camera
+			//? if <=1.21.5 {
+			/*.getPosition();
+			 *///? } else if <=1.21.10 {
+			/*.position();
+			 *///?} else {
+			.position();
+		//?}
+
+		//? if >=26.2 {
+		/*var poseStack = context.poseStack();
+		poseStack.pushPose();
+		poseStack.translate(blockPos.getX() - camPos.x, blockPos.getY() - camPos.y, blockPos.getZ() - camPos.z);
+		context.submitNodeCollector().submitShapeOutline(
+			poseStack,
+			blockState.getShape(client.level, blockPos, net.minecraft.world.phys.shapes.CollisionContext.of(camera.entity())),
+			RenderTypes.lines(),
+			CommonColors.BLACK,
+			client.getWindow().getAppropriateLineWidth(),
+			false
+		);
+		poseStack.popPose();
+		*///?} else {
+
+		//? if <26.1 {
+		VertexConsumer consumer = context.consumers().getBuffer(
+		 //? } else
+		//VertexConsumer consumer = context.bufferSource().getBuffer(
+			//? if <=1.21.10 {
+			/*RenderType.lines()
+			 *///?} else {
+			RenderTypes.lines()
+			//?}
+		);
+
+		//? if <1.21.10 {
+			/*((WorldRendererInvoker) context.worldRenderer()).invokeRenderHitOutline(
+				context.matrixStack(),
+				consumer,
+				client.player,
+				camPos.x, camPos.y, camPos.z,
+				blockPos,
+				blockState,
+				CommonColors.BLACK
+			);
+			*///?} else {
+		//? if <26.1 {
+		((WorldRendererInvoker) context.worldRenderer()).invokeRenderHitOutline(
+		 //? } else
+		//((WorldRendererInvoker) context.levelRenderer()).invokeRenderHitOutline(
+			//? if <26.1 {
+			context.matrices(),
+			 //? } else
+			//context.poseStack(),
+			consumer,
+			camPos.x, camPos.y, camPos.z,
+			//? if <26.1 {
+				new BlockOutlineRenderState(
+					blockPos,
+					false,
+					false,
+					blockState.getShape(client.level, blockPos)
+				),
+				//? } else {
+			/*new BlockOutlineRenderState(
+				blockPos,
+				false,
+				false,
+				blockState.getShape(client.level, blockPos, net.minecraft.world.phys.shapes.CollisionContext.of(camera.entity()))
+			),
+			*///? }
+			CommonColors.BLACK/*? if >=1.21.11 {*/, client.getWindow().getAppropriateLineWidth()/*?}*/
+		);
+		//?}
+		//?}
+	}
+
 	{
 
 		//? if <26.1 {
@@ -133,67 +218,7 @@ public class AirPlaceFeature extends ClientToggleableFeature {
 			if (blockState == null)
 				return;
 
-			/* render block outline */
-			Camera camera = client.gameRenderer.getMainCamera();
-			Vec3 camPos = camera
-				//? if <=1.21.5 {
-				/*.getPosition();
-				*///? } else if <=1.21.10 {
-				/*.position();
-			    *///?} else {
-			    .position();
-			    //?}
-
-			//? if <26.1 {
-			VertexConsumer consumer = context.consumers().getBuffer(
-			//? } else
-			//VertexConsumer consumer = context.bufferSource().getBuffer(
-				//? if <=1.21.10 {
-				/*RenderType.lines()
-				*///?} else {
-				RenderTypes.lines()
-				//?}
-			);
-
-			//? if <1.21.10 {
-			/*((WorldRendererInvoker) context.worldRenderer()).invokeRenderHitOutline(
-				context.matrixStack(),
-				consumer,
-				client.player,
-				camPos.x, camPos.y, camPos.z,
-				blockPos,
-				blockState,
-				CommonColors.BLACK
-			);
-			*///?} else {
-			//? if <26.1 {
-			((WorldRendererInvoker) context.worldRenderer()).invokeRenderHitOutline(
-			//? } else
-			//((WorldRendererInvoker) context.levelRenderer()).invokeRenderHitOutline(
-				//? if <26.1 {
-				context.matrices(),
-				//? } else
-				//context.poseStack(),
-				consumer,
-				camPos.x, camPos.y, camPos.z,
-				//? if <26.1 {
-				new BlockOutlineRenderState(
-					blockPos,
-					false,
-					false,
-					blockState.getShape(client.level, blockPos)
-				),
-				//? } else {
-				/*new BlockOutlineRenderState(
-					blockPos,
-					false,
-					false,
-					blockState.getShape(client.level, blockPos, net.minecraft.world.phys.shapes.CollisionContext.of(camera.entity()))
-				),
-				*///? }
-				CommonColors.BLACK/*? if >=1.21.11 {*/, client.getWindow().getAppropriateLineWidth()/*?}*/
-			);
-			//?}
+			renderBlockOutline(context, client, blockPos, blockState);
 		};
 
 		//? if <1.21.10 {

--- a/src/client/java/tools/redstone/redstonetools/mixin/features/WorldRendererInvoker.java
+++ b/src/client/java/tools/redstone/redstonetools/mixin/features/WorldRendererInvoker.java
@@ -15,6 +15,7 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(LevelRenderer.class)
 public interface WorldRendererInvoker {
+	//? if <26.2 {
 	@Invoker
 	//? if <=1.21.8 {
 	/*void invokeRenderHitOutline(PoseStack matrices, VertexConsumer vertexConsumer, Entity entity, double cameraX, double cameraY, double cameraZ, BlockPos pos, BlockState state, int color);
@@ -22,5 +23,6 @@ public interface WorldRendererInvoker {
 	/*void invokeRenderHitOutline(PoseStack matrices, VertexConsumer vertexConsumer, double x, double y, double z, BlockOutlineRenderState state, int color);
 	*///?} else {
 	void invokeRenderHitOutline(PoseStack matrices, VertexConsumer vertexConsumer, double x, double y, double z, BlockOutlineRenderState state, int color, float lineWidth);
+	//?}
 	//?}
 }

--- a/src/main/java/tools/redstone/redstonetools/utils/SignalBlock.java
+++ b/src/main/java/tools/redstone/redstonetools/utils/SignalBlock.java
@@ -20,6 +20,18 @@ public enum SignalBlock {
 	COMMAND_BLOCK(Blocks.COMMAND_BLOCK, SignalBlockSupplier.commandBlock()),
 	AUTO(null, null);
 
+	/**
+	 * Signal strength at which {@code /ssb} switches from a container to a command block.
+	 *
+	 * <p>26.2 validates container contents strictly, so overstacked slots are dropped and a
+	 * container can no longer exceed 15. Below 26.2 the overstacking trick still works, so the
+	 * container is used up to the point where a comparator can no longer read it.
+	 */
+	//? if <26.2 {
+	private static final int COMMAND_BLOCK_THRESHOLD = 1780;
+	 //?} else
+	//private static final int COMMAND_BLOCK_THRESHOLD = 16;
+
 	private final Block block;
 	private final SignalBlockSupplier supplier;
 
@@ -29,7 +41,7 @@ public enum SignalBlock {
 	}
 
 	public static SignalBlock getBestBlock(int signal) {
-		return signal < 1780
+		return signal < COMMAND_BLOCK_THRESHOLD
 				? BARREL
 				: COMMAND_BLOCK;
 	}

--- a/src/main/java/tools/redstone/redstonetools/utils/SignalBlockSupplier.java
+++ b/src/main/java/tools/redstone/redstonetools/utils/SignalBlockSupplier.java
@@ -10,10 +10,18 @@ import net.minecraft.util.Mth;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.item.component.ItemContainerContents;
+//? if >=1.21.10 {
+import net.minecraft.world.item.component.TypedEntityData;
+//?} else {
+/*import net.minecraft.world.item.component.CustomData;
+*///?}
 import net.minecraft.world.level.block.Block;
-
+//? if >=26.2 {
+/*import net.minecraft.world.level.block.entity.BlockEntityTypes;
+*///?} else if >=1.21.10 {
+import net.minecraft.world.level.block.entity.BlockEntityType;
+//?}
 @FunctionalInterface
 public interface SignalBlockSupplier {
 
@@ -73,9 +81,19 @@ public interface SignalBlockSupplier {
 			CompoundTag blockEntityNbt = new CompoundTag();
 			blockEntityNbt.putInt("SuccessCount", signalStrength);
 
-			CustomData blockEntityData = CustomData.of(blockEntityNbt);
-
-			commandBlockStack.set(DataComponents.CUSTOM_DATA, blockEntityData);
+			//? if <1.21.10  {
+			/*blockEntityNbt.putString("id", "minecraft:command_block");
+			commandBlockStack.set(DataComponents.BLOCK_ENTITY_DATA, CustomData.of(blockEntityNbt));
+			*///?} else {
+			commandBlockStack.set(
+				DataComponents.BLOCK_ENTITY_DATA,
+				//? if >=26.2 {
+				/*TypedEntityData.of(BlockEntityTypes.COMMAND_BLOCK, blockEntityNbt)
+				*///?} else {
+				TypedEntityData.of(BlockEntityType.COMMAND_BLOCK, blockEntityNbt)
+				//?}
+			);
+			//?}
 			return commandBlockStack;
 		};
 	}

--- a/src/main/java/tools/redstone/redstonetools/utils/SignalBlockSupplier.java
+++ b/src/main/java/tools/redstone/redstonetools/utils/SignalBlockSupplier.java
@@ -109,7 +109,10 @@ public interface SignalBlockSupplier {
 
 	private static Item getBestItem(int signalStrength, int slots) {
 		if (signalStrength > 15)
+			//? if <26.2 {
 			return Items.WHITE_SHULKER_BOX;
+			//?} else
+			//return Items.DYED_SHULKER_BOX.white();
 		else if (slots >= 15)
 			return Items.WOODEN_SHOVEL;
 		else

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
   "depends": {
     "fabricloader": ">=0.18.1",
     "fabric-api": "*",
-    "minecraft": ">=1.21.4 <=${minecraft_version_out}"
+    "minecraft": ">=1.21.4 <=26.2"
   },
   "recommends": {
     "worldedit": "*",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,7 +37,7 @@
   "depends": {
     "fabricloader": ">=0.18.1",
     "fabric-api": "*",
-    "minecraft": ">=1.21.4 <=26.1.2"
+    "minecraft": ">=1.21.4 <=${minecraft_version_out}"
   },
   "recommends": {
     "worldedit": "*",

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -1,0 +1,7 @@
+minecraft_version=26.2
+minecraft_version_out=26.2
+
+fabric_version=0.156.0+26.2
+malilib_version=26.2:0.29.3
+malilib_api_version=0.8.3-26.2
+worldedit_version=26.2:8.0.0-SNAPSHOT


### PR DESCRIPTION
Adds 26.2 as a seventh Stonecutter target. Also carries three fixes for bugs that already existed on main and got in the way.

**Behaviour change worth reading before merging.** On 26.2, `/ssb` above 15 now gives a command block instead of a container. 26.2 validates container contents strictly, so overstacked slots are silently replaced by EMPTY and you get an empty barrel. Overstacking is how the >15 range worked, and Mojang closed it. Below 26.2 nothing changes.

Commits, oldest first:

- **Run malilib-api-processor on the client source set only.** With `splitEnvironmentSourceSets()` the processor ran twice and wrote `META-INF/kr1v/index.json` at the same jar path both times. Loom <=1.16 silently dropped one, so our shipped 1.21.x jars have only ever contained the client half. Loom 1.17 hard-fails instead, which is how it surfaced. Every malilib-api usage is client side, so scoping the processor there fixes it at the source. Upstream issue: kr1viah/malilib-api#3
- **Build CI on Java 25.** `build_reusable.yml` still installed Java 21 while `publish.yml` was already on 25. The 26.x targets compile with `--release 25`.
- **Fix /ssb command blocks never carrying their signal.** SuccessCount was written to `CUSTOM_DATA`, which is item level data. `BLOCK_ENTITY_DATA` is what gets copied into the block entity on placement, so every /ssb command block has been outputting 0. Affects all seven versions, fixed on all seven.
- **Bump Gradle to 9.5.1 and Loom to 1.17.** Required by 26.2 per the Fabric announcement.
- **Add Minecraft 26.2 target.** Version file plus the API changes: dyed shulker box items collapsed into a ColorCollection, screen handling moved off Minecraft onto Gui, LevelRenderer.renderHitOutline replaced by the submit node model, and GameRenderer.getMainCamera renamed.

Tested in game on 26.2, 26.1.2 and 1.21.4 (ssb across all versions): mod loads, airplace outline renders in the right place, config menu and macro editor, macros run, //rstack, //colorcode, /ssb across the range.

One thing that is not new but was never written down anywhere: a command block only keeps its SuccessCount if you place it in creative with permission level 2. Vanilla restriction on command block data, applies on every version.

> [!IMPORTANT]
Here's an attachement that contains the diff file to apply to the wiki :
[diff.txt](https://github.com/user-attachments/files/30593578/diff.txt)
